### PR TITLE
Allow for non empty string in `--query` argument

### DIFF
--- a/ovs-stat.sh
+++ b/ovs-stat.sh
@@ -204,7 +204,10 @@ while (($#)); do
             DO_ACTIONS[QUIET]=true
             DO_ACTIONS[SHOW_SUMMARY]=false
             DO_ACTIONS[RUN_QUERY]=true
-            QUERY_STR="$2"  
+            QUERY_STR=""
+            if (( $# > 1 )) && [[ ! $2 =~ ^-- ]]; then
+              QUERY_STR="$2"
+            fi
             shift
             ;;
         -p|--results-path)


### PR DESCRIPTION
In order to get a list of supported query options, the empty string
needs to be passed to the `--query` option. This change modifies the
command line parser's behavior to allow for zero arguments to
`--query` to make the explicit empty string unnecessary.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>